### PR TITLE
Fix missing tool-call handling in SentimentAgent

### DIFF
--- a/src/agent/sentiment.py
+++ b/src/agent/sentiment.py
@@ -33,6 +33,12 @@ class SentimentAgent(MCPAgent):
 
     special_tool_names: List[str] = Field(default_factory=lambda: [Terminate().name])
 
+    async def tool_call(self, name: str, params: Dict[str, Any]) -> ToolResult:
+        """Convenience wrapper to execute a tool by name."""
+        if not self.available_tools:
+            raise RuntimeError("No tools available")
+        return await self.available_tools.execute(name=name, tool_input=params)
+
     async def run(
         self, request: Optional[str] = None, stock_code: Optional[str] = None
     ) -> Any:
@@ -68,12 +74,12 @@ class SentimentAgent(MCPAgent):
             
             # 1. 强制执行新闻搜索
             try:
-                news_result = await self.tool_call("web_search", {
-                    "query": f"{stock_code} 股票 最新消息 舆情",
-                    "max_results": 10
-                })
-                if news_result and news_result.success:
-                    analysis_tasks.append(("news_search", news_result.data))
+                news_result = await self.tool_call(
+                    "web_search",
+                    {"query": f"{stock_code} 股票 最新消息 舆情", "max_results": 10},
+                )
+                if news_result and not news_result.error:
+                    analysis_tasks.append(("news_search", news_result.output))
                     logger.info(f"新闻搜索成功: {stock_code}")
                 else:
                     logger.warning(f"新闻搜索失败: {stock_code}")
@@ -82,12 +88,12 @@ class SentimentAgent(MCPAgent):
             
             # 2. 强制执行社交媒体分析
             try:
-                social_result = await self.tool_call("web_search", {
-                    "query": f"{stock_code} 股吧 讨论 情绪",
-                    "max_results": 5
-                })
-                if social_result and social_result.success:
-                    analysis_tasks.append(("social_media", social_result.data))
+                social_result = await self.tool_call(
+                    "web_search",
+                    {"query": f"{stock_code} 股吧 讨论 情绪", "max_results": 5},
+                )
+                if social_result and not social_result.error:
+                    analysis_tasks.append(("social_media", social_result.output))
                     logger.info(f"社交媒体分析成功: {stock_code}")
                 else:
                     logger.warning(f"社交媒体分析失败: {stock_code}")
@@ -96,12 +102,12 @@ class SentimentAgent(MCPAgent):
             
             # 3. 强制执行舆情分析工具
             try:
-                sentiment_result = await self.tool_call("sentiment_analysis", {
-                    "stock_code": stock_code,
-                    "analysis_type": "comprehensive"
-                })
-                if sentiment_result and sentiment_result.success:
-                    analysis_tasks.append(("sentiment_analysis", sentiment_result.data))
+                sentiment_result = await self.tool_call(
+                    "sentiment_analysis",
+                    {"stock_code": stock_code, "analysis_type": "comprehensive"},
+                )
+                if sentiment_result and not sentiment_result.error:
+                    analysis_tasks.append(("sentiment_analysis", sentiment_result.output))
                     logger.info(f"舆情分析工具成功: {stock_code}")
                 else:
                     logger.warning(f"舆情分析工具失败: {stock_code}")


### PR DESCRIPTION
## Summary
- add `tool_call` helper in `SentimentAgent`
- use new helper and check errors when calling analysis tools

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- ⚠️ `pre-commit` could not run because the command was not found

------
https://chatgpt.com/codex/tasks/task_e_6885c513c458833185446f04db0e698d